### PR TITLE
Add rake task to seed test user in development

### DIFF
--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -1,0 +1,9 @@
+namespace :development do
+  task create_test_user: :environment do
+    raise 'Can only be run on development!' unless Rails.env.development?
+
+    User.create!(name: 'user',
+                 email: 'user@example.com',
+                 password: 'testing123')
+  end
+end


### PR DESCRIPTION
There isn't any issue open regarding this; it is just something I wrote to improve my own workflow.

This PR adds a rake task that seeds a test user from the command line so that you don't need to go through the UI when you have a new database.

Use it by running the following command:

```
bundle exec rake development:create_test_user
```

Note that it will fail unless you are running in development.