### PR TITLE
Show flash messages with overlay

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -246,3 +246,18 @@ hr {
   height: 1px;
   background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(47, 47, 47, 0.27), rgba(0, 0, 0, 0));
 }
+
+.position-relative {
+  position: relative;
+
+  .alert {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
+  }
+}
+
+.alert {
+  margin-top: 20px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,8 @@ module ApplicationHelper
     end
     bar_color
   end
+
+  def devise_controller?
+    %w[registrations sessions].include?(controller_name)
+  end
 end

--- a/app/views/layouts/_notice.html.erb
+++ b/app/views/layouts/_notice.html.erb
@@ -1,11 +1,13 @@
 <div class="container">
-  <% if flash[:notice] %>
-    <div class="alert alert-success" role="alert"><%= flash[:notice] %></div>
-  <% end %>
-  <% if flash[:info] %>
-    <div class="alert alert-info" role="alert"><%= flash[:info] %></div>
-  <% end %>
-  <% if alert %>
-    <p class="alert alert-danger"><%= alert %></p>
-  <% end %>
+  <div class="<%= "col position-relative" if devise_controller? %>">
+    <% if flash[:notice] %>
+      <div class="alert alert-success" role="alert"><%= flash[:notice] %></div>
+    <% end %>
+    <% if flash[:info] %>
+      <div class="alert alert-info" role="alert"><%= flash[:info] %></div>
+    <% end %>
+    <% if alert %>
+      <div class="alert alert-danger" role="alert"><%= alert %></div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## Related issue

This PR close **[Flash messages overlay #8](#8)**.

## Objective

Now flash messages overlay instead of creating white space when appear. I have used the same `layouts/_notice.html.erb` partial with a new method to show or not CSS classes depending if the view is on devise controller.

## Screenshots

`Alert danger`
<img width="1197" alt="alert_danger" src="https://user-images.githubusercontent.com/631897/66566905-62e6df80-eb66-11e9-98f9-9ebb42a6a62e.png">

`Alert info`
![alert_info](https://user-images.githubusercontent.com/631897/66566856-49459800-eb66-11e9-9338-b96b6c3650eb.png)

`Alert success`
![alert_success](https://user-images.githubusercontent.com/631897/66566857-49459800-eb66-11e9-8cce-fe28731d7c63.png)