### PR TITLE
Added sign_up to post method

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -16,7 +16,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     super
   end
 
-  # POST /resource
+  # POST /resource/sign_up
   # def create
   #   super
   # end


### PR DESCRIPTION
Failed sign up attempts redirected to http://lifetoremindhub.herokuapp.com/users/ , which did not have the header and footer excluded/disabled. I added sign_up to the post method so failed attempts go to http://lifetoremindhub.herokuapp.com/users/sign_up