### PR TITLE
Configure Devise mailer to send password recovery emails

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>Olá <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>Alguém solicitou um link para alterar sua senha. Você pode fazer isso através do link abaixo.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'Mudar minha senha', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>Se você não solicitou isso, ignore este e-mail.</p>
+<p>Sua senha não será alterada até você acessar o link acima e criar um novo.</p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -57,11 +57,9 @@
       </a>
       -->
       <div class="text-center w-full p-t-115">
-						<span class="txt1">
-							Não tem uma conta?
-						</span>
-        <%= link_to "Cadastrar", new_user_registration_path, method: "get", class:"txt1 bo1 hov1" %>
+				<%= render "devise/shared/links" %>
       </div>
+
     </div>
   </div>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,26 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Entrar", new_session_path(resource_name), class: "btn btn-default btn-margin-bottom" %><br />
+  <%= link_to "Entrar", new_session_path(resource_name), class: "txt1 bo1 hov1" %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Cadastrar", new_registration_path(resource_name), class: "btn btn-default btn-margin-bottom" %><br />
+  <span class="txt1">Não tem uma conta?</span>
+  <%= link_to "Cadastrar", new_registration_path(resource_name), class: "txt1 bo1 hov1" %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Esqueceu sua senha?", new_password_path(resource_name) %><br />
+  <%= link_to "Esqueceu sua senha?", new_password_path(resource_name), class: "txt1 bo1 hov1" %><br />
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Não recebeu as instruções de confirmação?", new_confirmation_path(resource_name), class: "btn btn-default btn-margin-bottom" %><br />
+  <%= link_to "Não recebeu as instruções de confirmação?", new_confirmation_path(resource_name), class: "txt1 bo1 hov1" %><br />
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "btn btn-default btn-margin-bottom" %><br />
+  <%= link_to "Não recebeu instruções de desbloqueio?", new_unlock_path(resource_name), class: "txt1 bo1 hov1" %><br />
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Entrar com #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "btn btn-default btn-margin-bottom" %><br />
+    <%= link_to "Entrar com #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "txt1 bo1 hov1" %><br />
   <% end -%>
 <% end -%>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -24,6 +24,7 @@
         <% if current_user %>
           <li><%= link_to " Olá #{current_user.name}", edit_user_registration_path, method: "get", class: "lnr lnr-user" %></li>
           <li><%= link_to "Finalizar Demonstração", user_registration_path, data: {confirm: "Tem certeza que deseja sair? Por ser uma versão de demonstração, seu usuário será apagado."}, method: :delete %></li>
+          <li><%= link_to "Sair", destroy_user_session_path, method: :delete %>
       <% else %>
           <li><%= link_to "ENTRAR", new_user_session_path, method: "get" %></li>
           <li><%= link_to "CADASTRAR", new_user_registration_path, method: "get" %></a></li>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :smtp
+
+  # direct all emails sent in development to mailcatcher
+  config.action_mailer.smtp_settings = { address: "localhost", port: 1025 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
@@ -62,11 +62,28 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "ltr_#{Rails.env}"
 
-  config.action_mailer.perform_caching = false
+  config.action_mailer.perform_caching = true
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: ENV["GMAIL_DOMAIN"],
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_PASSWORD"]
+  }
+
+  config.action_mailer.default_url_options = { host: ENV["HOST"] }
+  Rails.application.routes.default_url_options[:host] = ENV["HOST"]
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,7 +9,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '3b82e2bec5106bc3b699096f8f2f7f0807731203b4acca27d2ee7064c9ec2fe3d45f35840fcd903421a059ac9de9044355995439688da3fcb3bc3e44de6c1fa6'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'noreply@lifetoremind.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/spec/integration/password_reset_integration.rb
+++ b/spec/integration/password_reset_integration.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature "Password Reset", type: :feature do
+  let(:user) { FactoryBot.create(:user) }
+
+  context "when a user forgets their password" do
+
+    scenario "user sees a 'Forgot your password?' link on the sign in page" do
+      visit new_user_session_path
+
+      expect(page).to have_content("Esqueceu sua senha?")
+    end
+
+
+    scenario "user can reset their password" do
+      visit new_user_session_path
+
+      click_on "Esqueceu sua senha?"
+      expect(page).to have_current_path(new_user_password_path)
+
+      fill_in "user_email", with: user.email
+      click_button "Me mande as instruções de recuperação de senha"
+
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content("Dentro de minutos, você receberá um e-mail com instruções para a troca da sua senha.")
+      expect(Devise.mailer.deliveries.count).to eq 1
+
+      visit password_reset_url(get_reset_password_token_from_email)
+
+      fill_in "user_password", with: "new_password"
+      fill_in "user_password_confirmation", with: "new_password"
+      click_button "Mudar minha senha"
+
+      expect(page).to have_content("Sua senha foi alterada com sucesso. Você está logado.")
+      expect(page).to have_current_path(root_path)
+    end
+  end
+end
+
+def password_reset_url(token)
+  "#{edit_user_password_path}?reset_password_token=#{token}"
+end
+
+
+def get_reset_password_token_from_email
+  email_message = Devise.mailer.deliveries[0].body.raw_source
+  token_index = email_message.index("reset_password_token") + "reset_password_token".length + 1
+  email_message[token_index...email_message.index("\"", token_index)]
+end


### PR DESCRIPTION
### What
This PR addresses this issue [https://github.com/eduqg/LifeToRemind/issues/5](https://github.com/eduqg/LifeToRemind/issues/5). Configuring Action Mailer options and setting up the UI so that users who want to reset their password have a way to do so.

### Why
We need to be able to send password reset instructions to users when they forget their passwords.

### Testing
- [ ] Install the `mailcatcher` gem with the command `gem install mailcatcher` before executing the next steps (This PR also sets up the app so that emails sent in dev environment go to mailcatcher)
- [ ] Start up mailcatcher by running `mailcatcher` command in your terminal
- [ ] Open the mailcatcher UI in another browser tab by visiting 'http://127.0.0.1:1080/'
- [ ] Go back to the app and Sign up with an email and a password and then sign out
- [ ] Visit the Sign in page
- [ ] Click on the "Forgot your password" link
- [ ] Assert that the link takes you to a page where you are required to provide your email
- [ ] Fill in your email details and submit the form
- [ ] Go to the mailcatcher tab and assert that a new Password Reset email was sent
- [ ] Click on the link in the email and assert that you are taken to the password reset page in the app
- [ ] Set up a new password and submit the form
- [ ] Assert that you are redirected to the home page of the app
- [ ] Sign out and sign in again with the new password to verify that the new password has taken effect


### Additional Information
- The PR configures the smtp server to be gmail
- For this feature to work in production we will need to create environment variable with gmail credentials, namely: `GMAIL_DOMAIN`, `GMAIL_USERNAME`, `GMAIL_PASSWORD` and `HOST` where host is the base url of the app.