### PR TITLE
Add responsibility to swotedit table

### DIFF
--- a/app/assets/stylesheets/text_side_button.scss
+++ b/app/assets/stylesheets/text_side_button.scss
@@ -76,7 +76,6 @@
 .field-group-swot {
   display: flex;
   flex-direction: row;
-  width: 350px;
   font-family: Raleway-Black;
   margin-left: 10px;
   margin-right: 45px


### PR DESCRIPTION
It closes issue #18.

I just removed the 'field-group-swot' scss class width attribute, and it makes the table responsive again.