### PR TITLE
Update gem wkhtmltopdf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.68.1', require: false
   gem 'rubocop-performance'
   gem 'rails-erd'
-  gem 'wkhtmltopdf-binary', '~> 0.12.4'
+  gem 'wkhtmltopdf-installer'
 end
 
 group :development do


### PR DESCRIPTION
The old bynary version was having some troubles, so using just the wkhtmltopdf-installer as Gem, this will get the last stable version of the lib, and that solved the issue #38 